### PR TITLE
refactor: config naming files to tasks

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -133,16 +133,16 @@ export async function po2mo({ input, config, cwd, ...args }: CliArgs) {
       !config.endsWith('po2mo.json') ? 'po2mo.json' : ''
     )
 
-    const configValue: Po2MoConfig = await import(configPath)
+    const { tasks }: Po2MoConfig = await import(configPath)
     // TODO: Refactor
     convertPromises.push(
       ...(
         await Promise.all(
-          configValue.files.map((file) =>
+          tasks.map((task) =>
             getConvertPromises({
-              input: file.input,
-              output: file.output,
-              recursive: file.recursive ?? false,
+              input: task.input,
+              output: task.output,
+              recursive: task.recursive ?? false,
               cwd,
             })
           )

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export type Po2MoConfig = {
-  files: {
+  tasks: {
     input: string
     output?: string
     recursive?: boolean

--- a/test/cli/config/fixtures/input-as-dir/output-as-dir/po2mo.json
+++ b/test/cli/config/fixtures/input-as-dir/output-as-dir/po2mo.json
@@ -1,5 +1,5 @@
 {
-  "files": [
+  "tasks": [
     {
       "input": ".",
       "output": "./output"

--- a/test/cli/config/fixtures/input-as-dir/output-as-dir/recursive/po2mo.json
+++ b/test/cli/config/fixtures/input-as-dir/output-as-dir/recursive/po2mo.json
@@ -1,5 +1,5 @@
 {
-  "files": [
+  "tasks": [
     {
       "input": ".",
       "output": "./output",

--- a/test/cli/config/fixtures/input-as-dir/output-as-file/po2mo.json
+++ b/test/cli/config/fixtures/input-as-dir/output-as-file/po2mo.json
@@ -1,5 +1,5 @@
 {
-  "files": [
+  "tasks": [
     {
       "input": ".",
       "output": "./output.mo"

--- a/test/cli/config/fixtures/input-as-dir/po2mo.json
+++ b/test/cli/config/fixtures/input-as-dir/po2mo.json
@@ -1,5 +1,5 @@
 {
-  "files": [
+  "tasks": [
     {
       "input": "."
     }

--- a/test/cli/config/fixtures/input-as-dir/recursive/po2mo.json
+++ b/test/cli/config/fixtures/input-as-dir/recursive/po2mo.json
@@ -1,5 +1,5 @@
 {
-  "files": [
+  "tasks": [
     {
       "input": ".",
       "recursive": true

--- a/test/cli/config/fixtures/input-as-file/output-as-dir/po2mo.json
+++ b/test/cli/config/fixtures/input-as-file/output-as-dir/po2mo.json
@@ -1,5 +1,5 @@
 {
-  "files": [
+  "tasks": [
     {
       "input": "./input.po",
       "output": "./output"

--- a/test/cli/config/fixtures/input-as-file/output-as-file/po2mo.json
+++ b/test/cli/config/fixtures/input-as-file/output-as-file/po2mo.json
@@ -1,5 +1,5 @@
 {
-  "files": [
+  "tasks": [
     {
       "input": "./input.po",
       "output": "./output.mo"

--- a/test/cli/config/fixtures/input-as-file/po2mo.json
+++ b/test/cli/config/fixtures/input-as-file/po2mo.json
@@ -1,5 +1,5 @@
 {
-  "files": [
+  "tasks": [
     {
       "input": "./input.po"
     }

--- a/test/cli/config/fixtures/input-as-file/recursive/po2mo.json
+++ b/test/cli/config/fixtures/input-as-file/recursive/po2mo.json
@@ -1,5 +1,5 @@
 {
-  "files": [
+  "tasks": [
     {
       "input": "./input.po",
       "recursive": true


### PR DESCRIPTION
This PR maybe controversial of modifying the convention of a config file, but as of upgrading po2mo, config file is for handling multiple tasks, and for single task it is more recommended to use cli only.