### PR TITLE
hotfix: default behavior from locale dir to git based

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 > Please checkout the [v2 backlog](https://github.com/devjiwonchoi/po2mo/issues/37)
 
+---
+
 ```sh
 npx po2mo [options]
 ```
@@ -27,6 +29,10 @@ Options:
   --config <path>        specify config file path
   --cwd <cwd>            specify current working directory
 ```
+
+## Default Behavior
+
+By default, `po2mo` will convert any modified, staged, or added .po files from git. You can change the current working directory with the [`--cwd` option](#current-working-directory---cwd).
 
 ## Providing an Input
 
@@ -193,13 +199,7 @@ npx po2mo ./locale --output ./output --recursive
 
 Sometimes you need to specify the current working directory. Send it!
 
-## Conventions
-
-### `locale` directory
-
-If no input was provided, `po2mo` looks up for the `locale` directory on the current working directory (`cwd`), and convert all `.po` files recursively within the `locale` directory.
-
-### `po2mo.json`
+## Configuration
 
 We recommend you to be config-free, but most of the time there are edge cases where you need a work-around.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "po2mo",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "po to mo, it's simple.",
   "license": "MIT",
   "bin": "./dist/cli.js",

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -81,10 +81,6 @@ async function getConvertPromises({
   output &&= resolve(cwd, output)
 
   if (!input) {
-    logger.info(
-      `No input was provided. Converting .po files based on git status.`
-    )
-
     // TODO: Find a way to test this
     const { modified, not_added, staged } = await git(cwd).status()
     // TODO: Understand Set better
@@ -97,8 +93,9 @@ async function getConvertPromises({
     ]
 
     if (!poFilesFromGit.length) {
-      logger.warn('No .po files found in git status.')
-      return []
+      throw new Error(
+        'Could not find any modified, staged, or added .po files.'
+      )
     }
 
     return poFilesFromGit.map((poFile) => getConvertJobs(cwd, poFile))


### PR DESCRIPTION
Since there are some issues that by default, looking for `locale` dir throws ENOENT error, so it might not be the best case.

Resolves #63 